### PR TITLE
Redesign Scrabble icon with 3D tilted tile on white background

### DIFF
--- a/public/icon-192.svg
+++ b/public/icon-192.svg
@@ -1,10 +1,35 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
-  <!-- Scrabble tile background -->
-  <rect x="16" y="16" width="160" height="160" rx="12" fill="#fef3c7"/>
-  <!-- Subtle inner shadow/border -->
-  <rect x="16" y="16" width="160" height="160" rx="12" fill="none" stroke="#d4a574" stroke-width="2"/>
-  <!-- Letter S -->
-  <text x="96" y="128" font-family="system-ui, -apple-system, sans-serif" font-size="110" font-weight="bold" fill="#5c4a3d" text-anchor="middle">S</text>
-  <!-- Point value -->
-  <text x="156" y="160" font-family="system-ui, -apple-system, sans-serif" font-size="32" font-weight="600" fill="#8b7355" text-anchor="middle">1</text>
+  <!-- White background -->
+  <rect width="192" height="192" fill="#ffffff"/>
+
+  <!-- Drop shadow -->
+  <defs>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="3" dy="5" stdDeviation="5" flood-color="#000" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+
+  <!-- 3D tile group - tilted back ~30 degrees using perspective transform -->
+  <g transform="translate(96, 105)" filter="url(#shadow)">
+    <!-- Apply 3D tilt: scale Y to ~0.87 (cos 30°), slight skew for perspective -->
+    <g transform="scale(1, 0.87) skewX(-2)">
+      <!-- Tile top face -->
+      <rect x="-45" y="-52" width="90" height="90" rx="6" fill="#fef3c7"/>
+      <rect x="-45" y="-52" width="90" height="90" rx="6" fill="none" stroke="#d4a574" stroke-width="1.5"/>
+
+      <!-- Letter S -->
+      <text x="0" y="17" font-family="system-ui, -apple-system, sans-serif" font-size="60" font-weight="bold" fill="#5c4a3d" text-anchor="middle">S</text>
+
+      <!-- Point value -->
+      <text x="34" y="32" font-family="system-ui, -apple-system, sans-serif" font-size="18" font-weight="600" fill="#8b7355" text-anchor="middle">1</text>
+    </g>
+
+    <!-- Bottom edge (3D depth) -->
+    <g transform="scale(1, 0.87) skewX(-2)">
+      <path d="M-45,38 L-45,44 Q-45,48 -41,48 L41,48 Q45,48 45,44 L45,38" fill="#d4a574"/>
+    </g>
+
+    <!-- Right edge (3D depth) -->
+    <path d="M39,33 L42,36 L42,42 Q42,45 40,46 L37,43 L37,38 Q37,35 39,33" fill="#c9956a" transform="scale(1, 0.87) skewX(-2)"/>
+  </g>
 </svg>

--- a/public/icon-512.svg
+++ b/public/icon-512.svg
@@ -1,10 +1,35 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
-  <!-- Scrabble tile background -->
-  <rect x="42" y="42" width="428" height="428" rx="32" fill="#fef3c7"/>
-  <!-- Subtle inner shadow/border -->
-  <rect x="42" y="42" width="428" height="428" rx="32" fill="none" stroke="#d4a574" stroke-width="4"/>
-  <!-- Letter S -->
-  <text x="256" y="340" font-family="system-ui, -apple-system, sans-serif" font-size="290" font-weight="bold" fill="#5c4a3d" text-anchor="middle">S</text>
-  <!-- Point value -->
-  <text x="416" y="426" font-family="system-ui, -apple-system, sans-serif" font-size="85" font-weight="600" fill="#8b7355" text-anchor="middle">1</text>
+  <!-- White background -->
+  <rect width="512" height="512" fill="#ffffff"/>
+
+  <!-- Drop shadow -->
+  <defs>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="8" dy="12" stdDeviation="12" flood-color="#000" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+
+  <!-- 3D tile group - tilted back ~30 degrees using perspective transform -->
+  <g transform="translate(256, 280)" filter="url(#shadow)">
+    <!-- Apply 3D tilt: scale Y to ~0.87 (cos 30°), slight skew for perspective -->
+    <g transform="scale(1, 0.87) skewX(-2)">
+      <!-- Tile top face -->
+      <rect x="-120" y="-140" width="240" height="240" rx="16" fill="#fef3c7"/>
+      <rect x="-120" y="-140" width="240" height="240" rx="16" fill="none" stroke="#d4a574" stroke-width="3"/>
+
+      <!-- Letter S -->
+      <text x="0" y="45" font-family="system-ui, -apple-system, sans-serif" font-size="160" font-weight="bold" fill="#5c4a3d" text-anchor="middle">S</text>
+
+      <!-- Point value -->
+      <text x="90" y="85" font-family="system-ui, -apple-system, sans-serif" font-size="48" font-weight="600" fill="#8b7355" text-anchor="middle">1</text>
+    </g>
+
+    <!-- Bottom edge (3D depth) -->
+    <g transform="scale(1, 0.87) skewX(-2)">
+      <path d="M-120,100 L-120,112 Q-120,124 -108,124 L108,124 Q120,124 120,112 L120,100" fill="#d4a574"/>
+    </g>
+
+    <!-- Right edge (3D depth) -->
+    <path d="M104,87 L112,95 L112,108 Q112,116 106,120 L98,112 L98,100 Q98,92 104,87" fill="#c9956a" transform="scale(1, 0.87) skewX(-2)"/>
+  </g>
 </svg>


### PR DESCRIPTION
- Add white background to icons
- Make tile smaller and centered
- Apply 3D perspective with ~30 degree tilt using transform
- Add drop shadow and depth edges for 3D effect