### PR TITLE
Fix mobile share to only include URL

### DIFF
--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -281,18 +281,13 @@ export const GameScreen = ({ gameId, onEndGame }: Props) => {
 
   const handleShare = async () => {
     const url = window.location.href
-    const playerNames = players.map(p => p.name).join(' vs ')
 
     // Use native share only on mobile (iOS/Android), not on macOS
     const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
 
     if (isMobile && navigator.share) {
       try {
-        await navigator.share({
-          title: 'Scrabble Game',
-          text: `Join my Scrabble game: ${playerNames}`,
-          url,
-        })
+        await navigator.share({ url })
       } catch {
         // User cancelled or share failed - ignore
       }


### PR DESCRIPTION
Remove title and text from navigator.share() call so that
on mobile devices only the URL is shared without extra text.