### PR TITLE
Make mobile keyboard Go button submit the move

### DIFF
--- a/src/components/ScrabbleBoard.tsx
+++ b/src/components/ScrabbleBoard.tsx
@@ -381,6 +381,7 @@ const ScrabbleBoard = ({
         <input
           ref={hiddenInputRef}
           type="text"
+          enterKeyHint="go"
           autoCapitalize="characters"
           autoComplete="off"
           autoCorrect="off"


### PR DESCRIPTION
Add enterKeyHint="go" to the hidden input so the iOS virtual
keyboard's submit button fires an Enter key event instead of
just dismissing the keyboard.