### PR TITLE
Fix TypeScript build errors for type definitions

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,6 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,6 @@
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
-    "types": ["node"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
- Add src/vite-env.d.ts with vite/client type reference (standard Vite approach)
- Remove explicit 'types' field from tsconfig.app.json and tsconfig.node.json

The previous configuration used 'types: ["vite/client"]' and 'types: ["node"]'
which can cause TS2688 errors when TypeScript can't locate these type
definition files. Using the standard vite-env.d.ts approach and letting
TypeScript auto-discover types is more robust.