### PR TITLE
Prevent text selection throughout the app

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -163,7 +163,7 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    @apply border-border outline-ring/50 select-none;
   }
   html,
   body,


### PR DESCRIPTION
Add select-none to base styles to prevent accidental text selection
during touch interactions, improving the gameplay experience.