### PR TITLE
Hide score badge on cursor when score is zero

### DIFF
--- a/src/components/ScrabbleBoard.tsx
+++ b/src/components/ScrabbleBoard.tsx
@@ -502,7 +502,9 @@ const ScrabbleBoard = ({
                   <>
                     <div className="absolute inset-0 ring-[0.4cqw] ring-teal-600 ring-inset pointer-events-none z-10" />
                     {cursor && <CursorArrow direction={cursor.direction} />}
-                    {currentMoveScore !== null && <ScoreBadge score={currentMoveScore} />}
+                    {currentMoveScore !== null && currentMoveScore > 0 && (
+                      <ScoreBadge score={currentMoveScore} />
+                    )}
                   </>
                 )}
                 {highlighted && (


### PR DESCRIPTION
Only show the ScoreBadge component when the current move score is
greater than zero, not just when it's non-null.