### PR TITLE
MoveHistoryList: display failed challenges with x icon and challenged words

### DIFF
--- a/e2e/tests/move-actions.test.ts
+++ b/e2e/tests/move-actions.test.ts
@@ -134,7 +134,7 @@ test.describe("Move actions", () => {
       expect(await gamePage.getCurrentPlayerIndex()).toBe(1)
     })
 
-    test("failed challenge shows error toast", async ({ page }) => {
+    test("failed challenge shows error toast and records on scoresheet", async ({ page }) => {
       // Seed a game with a valid word (CAT is a valid word)
       await seedGameWithMoves(
         page,
@@ -169,6 +169,11 @@ test.describe("Move actions", () => {
 
       // Bob loses his turn for failed challenge, so it should be Alice's turn
       expect(await gamePage.getCurrentPlayerIndex()).toBe(0)
+
+      // Bob's scoresheet should show the failed challenge with the word
+      const bobPanel = page.locator('[role="region"][data-player="Bob"]')
+      await expect(bobPanel.getByText(/failed challenge/)).toBeVisible()
+      await expect(bobPanel.getByText(/CAT/)).toBeVisible()
     })
 
     test("challenge option only appears for the last move", async ({ page }) => {

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -269,8 +269,8 @@ export const GameScreen = ({ gameId, onEndGame }: Props) => {
           const invalidList = invalidWords.map(w => w.toUpperCase()).join(", ")
           toast.error(`${invalidList} ${invalidWords.length > 1 ? "are" : "is"} not valid`)
         } else {
-          // Challenge failed - challenger loses their turn
-          challengeMove(globalIndex, false)
+          // Challenge failed - challenger loses their turn, record the challenged words
+          challengeMove(globalIndex, false, words)
           toast.success(
             <div>
               <div className="font-medium">All words are valid:</div>

--- a/src/components/MoveHistoryList.tsx
+++ b/src/components/MoveHistoryList.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { IconPencil, IconArrowBackUp, IconAlertTriangle } from "@tabler/icons-react"
+import { IconPencil, IconArrowBackUp, IconAlertTriangle, IconX } from "@tabler/icons-react"
 
 export type MoveAction = "correct" | "undo" | "challenge"
 
@@ -36,6 +36,20 @@ export const MoveHistoryList = ({
                 {scorePrefix}
                 {entry.score}
               </span>
+            </div>
+          )
+        }
+
+        if (entry.isFailedChallenge) {
+          // Display failed challenge entry (not editable)
+          const challengedWords = entry.failedChallengeWords?.map(w => w.toUpperCase()).join(", ")
+          return (
+            <div key={i} className="flex justify-between gap-2 px-1 py-1.5 text-red-600 italic">
+              <span className="flex items-center gap-1 truncate">
+                <IconX size={12} className="shrink-0" />
+                <span>failed challenge{challengedWords ? `: ${challengedWords}` : ""}</span>
+              </span>
+              <span className="font-medium">0</span>
             </div>
           )
         }

--- a/src/lib/automergeTypes.ts
+++ b/src/lib/automergeTypes.ts
@@ -21,11 +21,17 @@ export type AdjustmentDoc = {
   bonus: number
 }
 
+/** Automerge-compatible failed challenge */
+export type FailedChallengeDoc = {
+  words: string[]
+}
+
 /** Automerge-compatible game move */
 export type GameMoveDoc = {
   playerIndex: number
   tilesPlaced: TilePlacement[]
   adjustment?: AdjustmentDoc
+  failedChallenge?: FailedChallengeDoc
 }
 
 /** Game status */

--- a/src/lib/getPlayerMoveHistory.ts
+++ b/src/lib/getPlayerMoveHistory.ts
@@ -12,6 +12,8 @@ export type MoveHistoryEntry = {
     deduction: number
     bonus: number
   }
+  isFailedChallenge?: boolean
+  failedChallengeWords?: string[]
 }
 
 type Options = {
@@ -39,6 +41,15 @@ export const getPlayerMoveHistory = (
           tiles: [],
           isAdjustment: true,
           adjustmentDetails: move.adjustment,
+        })
+      } else if (move.failedChallenge) {
+        // Failed challenge - pass with challenged words recorded
+        history.push({
+          words: [],
+          score: 0,
+          tiles: [],
+          isFailedChallenge: true,
+          failedChallengeWords: move.failedChallenge.words,
         })
       } else {
         const words = getWordsFromMove(move.tilesPlaced, boardState)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,11 +20,17 @@ export type Adjustment = {
   bonus: number
 }
 
+/** Failed challenge info */
+export type FailedChallenge = {
+  words: string[] // The words that were challenged but were valid
+}
+
 /** A move made by a specific player  */
 export type GameMove = {
   playerIndex: number
   tilesPlaced: Move
   adjustment?: Adjustment
+  failedChallenge?: FailedChallenge
 }
 
 /** Player state  */


### PR DESCRIPTION
Add failedChallenge field to GameMove type to record when a challenge
fails. When a player challenges a valid word and loses, the scoresheet
now displays "failed challenge: WORD" with an x icon in red text.