### PR TITLE
Fix Playwright test command in GitHub action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         run: pnpm exec playwright install --with-deps webkit
 
       - name: Run Playwright tests
-        run: pnpm pw
+        run: pnpm test:pw
 
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Change from `pnpm pw` to `pnpm test:pw` to match the correct script name in package.json.