### PR TITLE
Add generic undo/redo replacing move-specific undo

### DIFF
--- a/e2e/pages/game.page.ts
+++ b/e2e/pages/game.page.ts
@@ -331,10 +331,28 @@ export class GamePage {
     await entry.click()
   }
 
-  /** Select undo from the move action menu */
-  async undoMove(playerName: string, moveIndex: number) {
-    await this.openMoveMenu(playerName, moveIndex)
-    await this.page.getByRole("menuitem", { name: "Undo" }).click()
+  /** Click the global undo button */
+  async clickUndo() {
+    // Dismiss mobile keyboard if visible by pressing Escape
+    await this.pressKey("Escape")
+    await this.page.getByRole("button", { name: "Undo" }).click()
+  }
+
+  /** Click the global redo button */
+  async clickRedo() {
+    // Dismiss mobile keyboard if visible by pressing Escape
+    await this.pressKey("Escape")
+    await this.page.getByRole("button", { name: "Redo" }).click()
+  }
+
+  /** Check if undo button is enabled */
+  async isUndoEnabled(): Promise<boolean> {
+    return this.page.getByRole("button", { name: "Undo" }).isEnabled()
+  }
+
+  /** Check if redo button is enabled */
+  async isRedoEnabled(): Promise<boolean> {
+    return this.page.getByRole("button", { name: "Redo" }).isEnabled()
   }
 
   /** Select challenge from the move action menu */

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -26,6 +26,8 @@ import {
   IconPlayerPlay,
   IconX,
   IconShare,
+  IconArrowBackUp,
+  IconArrowForwardUp,
 } from "@tabler/icons-react"
 import { MobileKeyboard } from "./MobileKeyboard"
 
@@ -94,10 +96,13 @@ export const GameScreen = ({ gameId, onEndGame }: Props) => {
     stopTimer,
     commitMove,
     updateMove,
-    undoLastMove,
     challengeMove,
     endGame,
     endGameWithAdjustments,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
   } = useGame(gameId)
 
   const [newTiles, setNewTiles] = useState<BoardState>(createEmptyBoard)
@@ -236,16 +241,6 @@ export const GameScreen = ({ gameId, onEndGame }: Props) => {
     switch (action) {
       case "correct":
         handleEditMove(playerIndex, playerMoveIndex)
-        break
-
-      case "undo":
-        // Only allow undo of the last move
-        if (globalIndex === moves.length - 1) {
-          undoLastMove()
-          toast.success("Move undone")
-        } else {
-          toast.error("Can only undo the most recent move")
-        }
         break
 
       case "challenge": {
@@ -539,6 +534,24 @@ export const GameScreen = ({ gameId, onEndGame }: Props) => {
             </Button>
           </>
         : <>
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={undo}
+              disabled={!canUndo}
+              aria-label="Undo"
+            >
+              <IconArrowBackUp size={14} />
+            </Button>
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={redo}
+              disabled={!canRedo}
+              aria-label="Redo"
+            >
+              <IconArrowForwardUp size={14} />
+            </Button>
             {timerEverUsed ?
               <Button
                 className="flex-1"

--- a/src/components/MoveHistoryList.tsx
+++ b/src/components/MoveHistoryList.tsx
@@ -7,9 +7,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { IconPencil, IconArrowBackUp, IconAlertTriangle, IconX } from "@tabler/icons-react"
+import { IconPencil, IconAlertTriangle, IconX } from "@tabler/icons-react"
 
-export type MoveAction = "correct" | "undo" | "challenge"
+export type MoveAction = "correct" | "challenge"
 
 export const MoveHistoryList = ({
   history,
@@ -115,16 +115,10 @@ const MoveHistoryEntry = ({
             Correct
           </DropdownMenuItem>
           {isLastMove && (
-            <>
-              <DropdownMenuItem onClick={() => handleAction("undo")}>
-                <IconArrowBackUp size={16} />
-                Undo
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => handleAction("challenge")}>
-                <IconAlertTriangle size={16} />
-                Challenge
-              </DropdownMenuItem>
-            </>
+            <DropdownMenuItem onClick={() => handleAction("challenge")}>
+              <IconAlertTriangle size={16} />
+              Challenge
+            </DropdownMenuItem>
           )}
         </DropdownMenuContent>
       )}


### PR DESCRIPTION
- Add undo/redo state management with snapshot tracking in useGame.ts
- Remove undo from move dropdown menu (MoveHistoryList)
- Add global undo/redo buttons to GameScreen action bar
- Support undoing moves, passes, and challenges
- Update e2e tests for new undo/redo behavior