### PR TITLE
Add hide keyboard button with downward caret icon

### DIFF
--- a/src/components/MobileKeyboard.tsx
+++ b/src/components/MobileKeyboard.tsx
@@ -1,4 +1,4 @@
-import { IconBackspace } from "@tabler/icons-react"
+import { IconBackspace, IconChevronDown } from "@tabler/icons-react"
 import { cx } from "@/lib/cx"
 
 /** Direction indicator that mirrors the cursor style on the board */
@@ -136,6 +136,17 @@ export const MobileKeyboard = ({ onKeyPress, direction, visible }: Props) => {
           onMouseDown={handleKeyPress("Enter")}
         >
           Done
+        </button>
+        <button
+          type="button"
+          className={cx(
+            "flex h-11 w-12 items-center justify-center rounded-md bg-neutral-300 font-semibold shadow-sm",
+            "active:bg-neutral-400 touch-manipulation select-none",
+          )}
+          onTouchStart={handleKeyPress("Escape")}
+          onMouseDown={handleKeyPress("Escape")}
+        >
+          <IconChevronDown size={22} />
         </button>
       </div>
     </div>


### PR DESCRIPTION
Adds a button to the mobile keyboard bottom row that triggers the Escape
key, which clears the cursor and hides the virtual keyboard.