### PR TITLE
Add check option for moves - like challenge but without consequences

### DIFF
--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -285,6 +285,67 @@ export const GameScreen = ({ gameId, onEndGame }: Props) => {
         }
         break
       }
+
+      case "check": {
+        // Check words without any consequences (no turn loss, no move removal)
+        const move = moves[globalIndex]
+        const boardBeforeMove = getBoardExcludingMove(moves, globalIndex)
+        const words = getWordsFromMove(move.tilesPlaced, boardBeforeMove)
+
+        const invalidWords = words.filter(word => !isValidWord(word))
+        const validWords = words.filter(word => isValidWord(word))
+
+        if (invalidWords.length > 0) {
+          // Some words are invalid
+          toast.error(
+            <div>
+              <div className="font-medium">Invalid words found:</div>
+              <ul className="mt-1 list-disc pl-4">
+                {invalidWords.map(word => (
+                  <li key={word}>
+                    <strong>{word.toUpperCase()}</strong>
+                  </li>
+                ))}
+              </ul>
+              {validWords.length > 0 && (
+                <>
+                  <div className="font-medium mt-2">Valid words:</div>
+                  <ul className="mt-1 list-disc pl-4">
+                    {validWords.map(word => {
+                      const entry = getWordDefinition(word)
+                      const def = entry?.definitions[0]?.text ?? "no definition"
+                      return (
+                        <li key={word}>
+                          <strong>{word.toUpperCase()}</strong>: {def}
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </>
+              )}
+            </div>,
+          )
+        } else {
+          // All words are valid
+          toast.success(
+            <div>
+              <div className="font-medium">All words are valid:</div>
+              <ul className="mt-1 list-disc pl-4">
+                {words.map(word => {
+                  const entry = getWordDefinition(word)
+                  const def = entry?.definitions[0]?.text ?? "no definition"
+                  return (
+                    <li key={word}>
+                      <strong>{word.toUpperCase()}</strong>: {def}
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>,
+          )
+        }
+        break
+      }
     }
   }
 

--- a/src/components/MoveHistoryList.tsx
+++ b/src/components/MoveHistoryList.tsx
@@ -7,9 +7,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { IconPencil, IconAlertTriangle, IconX } from "@tabler/icons-react"
+import { IconPencil, IconAlertTriangle, IconX, IconEye } from "@tabler/icons-react"
 
-export type MoveAction = "correct" | "challenge"
+export type MoveAction = "correct" | "challenge" | "check"
 
 export const MoveHistoryList = ({
   history,
@@ -113,6 +113,10 @@ const MoveHistoryEntry = ({
           <DropdownMenuItem onClick={() => handleAction("correct")}>
             <IconPencil size={16} />
             Correct
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => handleAction("check")}>
+            <IconEye size={16} />
+            Check
           </DropdownMenuItem>
           {isLastMove && (
             <DropdownMenuItem onClick={() => handleAction("challenge")}>


### PR DESCRIPTION
Allows players to verify if words are valid without any penalties:
- Available for any move (not just the last one)
- Shows valid/invalid words with definitions
- No turn loss or move removal regardless of result