### PR TITLE
Fix blank tile dialog on mobile Safari by using inline letter buttons

### DIFF
--- a/e2e/tests/blank-tile-input.test.ts
+++ b/e2e/tests/blank-tile-input.test.ts
@@ -6,16 +6,11 @@ test.describe("Blank tile input", () => {
   let gamePage: GamePage
 
   test.beforeEach(async ({ page }) => {
-    // Inject touch support before app loads so isMobile detection returns true
-    await page.addInitScript(() => {
-      Object.defineProperty(window, "ontouchstart", { value: null, writable: true })
-      Object.defineProperty(navigator, "maxTouchPoints", { value: 1, writable: true })
-    })
     await seedTwoPlayerGame(page)
     gamePage = new GamePage(page)
   })
 
-  test("blank tile dialog accepts letter via mobile keyboard tap", async ({ page }) => {
+  test("blank tile dialog accepts letter via button tap", async ({ page }) => {
     // Place C, blank, T at center to make C_T
     await gamePage.clickCell(7, 7)
     await gamePage.typeLetters("C")
@@ -29,33 +24,16 @@ test.describe("Blank tile input", () => {
     const dialog = page.getByRole("dialog", { name: /What letter/ })
     await dialog.waitFor({ state: "visible" })
 
-    // Find the "A" button on the dialog's mobile keyboard and simulate a tap
-    // MobileKeyboard ignores mousedown when touch is available, so we dispatch
-    // a touchstart event directly. Use Event since Touch API isn't available in
-    // desktop Firefox.
-    const letterRegistered = await page.evaluate(() => {
-      const allButtons = Array.from(document.querySelectorAll("button"))
-      const aButtons = allButtons.filter(b => b.textContent?.trim() === "A")
-      const aButton = aButtons[aButtons.length - 1]
-      if (!aButton) return "no button found"
-
-      // Dispatch a touchstart event - React will handle it via its event system
-      const event = new Event("touchstart", { bubbles: true, cancelable: true })
-      aButton.dispatchEvent(event)
-      return "dispatched"
-    })
-
-    expect(letterRegistered).toBe("dispatched")
-
-    // The dialog should still be open
-    await expect(dialog).toBeVisible()
+    // Click the "A" letter button inside the dialog
+    const aButton = dialog.getByRole("button", { name: "A", exact: true })
+    await aButton.click()
 
     // The Done button should now be enabled (blank was filled)
     const doneButton = dialog.getByRole("button", { name: "Done" })
     await expect(doneButton).toBeEnabled({ timeout: 2000 })
 
-    // Click Done to confirm (using force since overlay may intercept)
-    await doneButton.click({ force: true })
+    // Click Done to confirm
+    await doneButton.click()
 
     // Dialog should close
     await dialog.waitFor({ state: "detached" })
@@ -78,7 +56,7 @@ test.describe("Blank tile input", () => {
     const dialog = page.getByRole("dialog", { name: /What letter/ })
     await dialog.waitFor({ state: "visible" })
 
-    // Type a letter using hardware keyboard (not mobile keyboard)
+    // Type a letter using hardware keyboard
     await page.keyboard.press("A")
 
     // The Done button should be enabled
@@ -86,7 +64,7 @@ test.describe("Blank tile input", () => {
     await expect(doneButton).toBeEnabled({ timeout: 2000 })
 
     // Click Done
-    await doneButton.click({ force: true })
+    await doneButton.click()
     await dialog.waitFor({ state: "detached" })
 
     expect(await gamePage.getPlayerScore(0)).toBeGreaterThan(0)

--- a/src/components/BlankLetterDialog.tsx
+++ b/src/components/BlankLetterDialog.tsx
@@ -1,27 +1,31 @@
 import { useState, useEffect, useCallback } from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
+import { IconBackspace } from "@tabler/icons-react"
 import {
   Dialog,
+  DialogContent,
   DialogHeader,
   DialogTitle,
   DialogDescription,
-  DialogOverlay,
-  DialogPortal,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Tile } from "./Tile"
-import { MobileKeyboard } from "./MobileKeyboard"
-import { cn } from "@/lib/utils"
+import { cx } from "@/lib/cx"
+
+const ROWS = [
+  ["Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P"],
+  ["A", "S", "D", "F", "G", "H", "J", "K", "L"],
+  ["Z", "X", "C", "V", "B", "N", "M"],
+]
 
 /**
  * Dialog for assigning letters to blank tiles after a move is committed.
- * Shows the word(s) with blanks as empty slots and accepts keyboard input.
+ * Shows the word(s) with blanks as empty slots and accepts keyboard/tap input.
+ * Letter buttons are rendered inline inside the dialog to avoid mobile Safari
+ * issues with touch events being blocked by the dialog overlay.
  */
 export const BlankLetterDialog = ({ open, blanks, onComplete, onCancel }: Props) => {
   // Track letters assigned to each blank position
   const [assignedLetters, setAssignedLetters] = useState<string[]>([])
-  const [isMobile] = useState(() => "ontouchstart" in window || navigator.maxTouchPoints > 0)
 
   // Reset state when dialog opens with new blanks
   useEffect(() => {
@@ -33,13 +37,11 @@ export const BlankLetterDialog = ({ open, blanks, onComplete, onCancel }: Props)
   const handleKeyPress = useCallback(
     (key: string) => {
       if (key === "Backspace") {
-        // Remove last assigned letter
         setAssignedLetters(prev => prev.slice(0, -1))
         return
       }
 
       if (key === "Enter") {
-        // Complete if all blanks are filled
         if (assignedLetters.length === blanks.length) {
           onComplete(assignedLetters)
         }
@@ -54,12 +56,11 @@ export const BlankLetterDialog = ({ open, blanks, onComplete, onCancel }: Props)
     [assignedLetters, blanks.length, onComplete],
   )
 
-  // Keyboard listener for desktop
+  // Hardware keyboard listener
   useEffect(() => {
     if (!open) return
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Ignore if modifier keys are pressed
       if (e.ctrlKey || e.metaKey || e.altKey) return
 
       if (e.key === "Backspace" || e.key === "Enter" || /^[a-zA-Z]$/.test(e.key)) {
@@ -79,10 +80,7 @@ export const BlankLetterDialog = ({ open, blanks, onComplete, onCancel }: Props)
 
   const allFilled = assignedLetters.length === blanks.length
 
-  // Build display showing the word(s) with blanks filled in
   const renderWordPreview = () => {
-    // Group blanks by their word context for display
-    // For now, just show the blanks with their assigned letters
     let letterIndex = 0
     return (
       <div className="flex flex-wrap gap-1 justify-center">
@@ -94,10 +92,7 @@ export const BlankLetterDialog = ({ open, blanks, onComplete, onCancel }: Props)
             <div
               key={i}
               className="relative"
-              style={{
-                width: "2.5rem",
-                height: "2.5rem",
-              }}
+              style={{ width: "2.5rem", height: "2.5rem" }}
             >
               <Tile letter={letter ?? ""} variant="new" />
               {isCurrent && (
@@ -117,56 +112,62 @@ export const BlankLetterDialog = ({ open, blanks, onComplete, onCancel }: Props)
 
   return (
     <Dialog open={open} onOpenChange={isOpen => !isOpen && onCancel()}>
-      {/* Manually compose the portal so the MobileKeyboard is inside it,
-          ensuring it shares the same stacking context as the dialog overlay */}
-      <DialogPortal>
-        <DialogOverlay />
-        <DialogPrimitive.Content
-          data-slot="dialog-content"
-          className={cn(
-            "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-80 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
-            "max-w-xs",
-          )}
-          onPointerDownOutside={e => e.preventDefault()}
-          onInteractOutside={e => e.preventDefault()}
-        >
-          <DialogHeader>
-            <DialogTitle>
-              {blanks.length === 1 ? "What letter is the blank?" : "What letters are the blanks?"}
-            </DialogTitle>
-            <DialogDescription>
-              Type the letter{blanks.length > 1 ? "s" : ""} for your blank tile
-              {blanks.length > 1 ? "s" : ""}
-            </DialogDescription>
-          </DialogHeader>
+      <DialogContent showCloseButton={false} className="max-w-xs">
+        <DialogHeader>
+          <DialogTitle>
+            {blanks.length === 1 ? "What letter is the blank?" : "What letters are the blanks?"}
+          </DialogTitle>
+          <DialogDescription>
+            Tap the letter for your blank tile{blanks.length > 1 ? "s" : ""}
+          </DialogDescription>
+        </DialogHeader>
 
-          <div className="py-4">{renderWordPreview()}</div>
+        <div className="py-2">{renderWordPreview()}</div>
 
-          <div className="flex justify-end gap-2">
-            <Button variant="outline" onClick={onCancel}>
-              Cancel
-            </Button>
-            <Button onClick={() => onComplete(assignedLetters)} disabled={!allFilled}>
-              Done
-            </Button>
-          </div>
+        {/* Inline letter buttons - works reliably on all browsers including mobile Safari */}
+        <div className="flex flex-col gap-1.5">
+          {ROWS.map((row, rowIndex) => (
+            <div key={rowIndex} className="flex justify-center gap-1">
+              {row.map(letter => (
+                <button
+                  key={letter}
+                  type="button"
+                  className={cx(
+                    "flex h-9 min-w-[9%] flex-1 max-w-9 items-center justify-center rounded-md bg-neutral-100 text-sm font-semibold",
+                    "shadow-[0_2px_0_0_var(--color-neutral-300)] active:shadow-none active:translate-y-[2px]",
+                    "touch-manipulation select-none",
+                  )}
+                  onClick={() => handleKeyPress(letter)}
+                >
+                  {letter}
+                </button>
+              ))}
+              {rowIndex === 2 && (
+                <button
+                  type="button"
+                  className={cx(
+                    "ml-1 flex h-9 min-w-[9%] flex-1 max-w-9 items-center justify-center rounded-md bg-neutral-200 font-semibold",
+                    "shadow-[0_2px_0_0_var(--color-neutral-400)] active:shadow-none active:translate-y-[2px]",
+                    "touch-manipulation select-none",
+                  )}
+                  onClick={() => handleKeyPress("Backspace")}
+                >
+                  <IconBackspace size={18} />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
 
-          <DialogPrimitive.Close
-            data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
-          >
-            <XIcon />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        </DialogPrimitive.Content>
-
-        {/* Mobile keyboard inside the portal - shares stacking context with overlay */}
-        {isMobile && (
-          <div className="fixed inset-x-0 bottom-0 z-[100]">
-            <MobileKeyboard onKeyPress={handleKeyPress} direction="horizontal" visible={true} />
-          </div>
-        )}
-      </DialogPortal>
+        <div className="flex justify-end gap-2 pt-1">
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={() => onComplete(assignedLetters)} disabled={!allFilled}>
+            Done
+          </Button>
+        </div>
+      </DialogContent>
     </Dialog>
   )
 }


### PR DESCRIPTION
The MobileKeyboard rendered outside DialogPrimitive.Content was having
its touch events intercepted by Radix's dialog overlay on mobile Safari.
Replace it with inline QWERTY letter buttons inside the dialog content,
which works reliably on all browsers.

https://claude.ai/code/session_01BtP1z5n66mQm7anYMZJ7Wy